### PR TITLE
fix spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Weekend Brunch is a Brunch Skeleton powered by
 
 - [Electron](<http://electron.atom.io/>) 
 - [Brunch](<http://brunch.io>)
-- [React] (<https://facebook.github.io/react/>)
+- [React](<https://facebook.github.io/react/>)
 - [Sass](<http://sass-lang.com/>)
 - [Bourbon](<http://bourbon.io/>)
 - [Neat](<http://neat.bourbon.io/>)


### PR DESCRIPTION
The extra space between [React] and (https://facebook.github.io/react/) caused the README.md to not render the link properly.